### PR TITLE
Logging improvements, Increase Equipment Proficiency filter priority

### DIFF
--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/FilterPresets/_AllDefaults.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/FilterPresets/_AllDefaults.lua
@@ -16,7 +16,7 @@ all_defaults.Equipment = {
 				TargetStat = ItemFilters.FilterFields.TargetStat.STACK_AMOUNT,
 				CompareStategy = ItemFilters.FilterFields.CompareStategy.HIGHER
 			},
-			[99] = { TargetStat = ItemFilters.FilterFields.TargetStat.PROFICIENCY },
+			[51] = { TargetStat = ItemFilters.FilterFields.TargetStat.PROFICIENCY },
 		}
 	}
 }

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Processors/_CoreProcessor.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Processors/_CoreProcessor.lua
@@ -16,16 +16,16 @@ local function ProcessWinners(partyMembersWithAmountWon, item, root, inventoryHo
 	for target, amount in pairs(partyMembersWithAmountWon) do
 		if amount > 0 then
 			if target == inventoryHolder then
-				Logger:BasicInfo(string.format("Target %s was determined to be inventoryHolder for %d of %s"
+				Logger:BasicInfo("Target %s was determined to be inventoryHolder for %d of %s"
 				, inventoryHolder
 				, amount
-				, item))
+				, item)
 			elseif target == "camp" then
 				Osi.SendToCampChest(item, inventoryHolder)
-				Logger:BasicInfo(string.format("Moved %s of %s to CAMP from %s"
+				Logger:BasicInfo("Moved %s of %s to CAMP from %s"
 				, amount
 				, item
-				, inventoryHolder))
+				, inventoryHolder)
 			else
 				Osi.SetOriginalOwner(item, inventoryHolder)
 
@@ -39,11 +39,11 @@ local function ProcessWinners(partyMembersWithAmountWon, item, root, inventoryHo
 					TableUtils:AddItemToTable_AddingToExistingAmount(TEMPLATES_BEING_TRANSFERRED[root], target, amount)
 				end
 
-				Logger:BasicInfo(string.format("Moved %s of %s to %s from %s"
+				Logger:BasicInfo("Moved %s of %s to %s from %s"
 				, amount
 				, item
 				, target
-				, inventoryHolder))
+				, inventoryHolder)
 			end
 		end
 	end
@@ -61,10 +61,11 @@ function Processor:ProcessFiltersForItemAgainstParty(item, root, inventoryHolder
 	local currentItemStackSize = Osi.GetStackAmount(item)
 	local partyMembers = {}
 
-	if (#Osi.DB_Players:Get(nil) < 1) then
+	if (#Osi.DB_Players:Get(nil) <= 1) then
 		Logger:BasicDebug("The party has one or fewer members - skipping processing")
 		return
 	end
+
 	for _, player in pairs(Osi.DB_Players:Get(nil)) do
 		table.insert(partyMembers, player[1])
 	end
@@ -123,13 +124,13 @@ function Processor:ProcessFiltersForItemAgainstParty(item, root, inventoryHolder
 
 				TableUtils:AddItemToTable_AddingToExistingAmount(targetsWithAmountWon, target, 1)
 				if Logger:IsLogLevelEnabled(Logger.PrintTypes.DEBUG) then
-					Logger:BasicDebug(string.format("Chose winner %s, new winners table is:\n%s",
+					Logger:BasicDebug("Chose winner %s, new winners table is:\n%s",
 						target,
-						Ext.Json.Stringify(targetsWithAmountWon)))
+						Ext.Json.Stringify(targetsWithAmountWon))
 				end
 
 				if Logger:IsLogLevelEnabled(Logger.PrintTypes.TRACE) then
-					Logger:BasicTrace("Winning command: " .. Ext.Json.Stringify(filter))
+					Logger:BasicTrace("Winning command: %s", Ext.Json.Stringify(filter))
 				end
 				break
 			end

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Processors/_FilterProcessors.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Processors/_FilterProcessors.lua
@@ -27,7 +27,7 @@ local StatFunctions = {
 			paramMap.root,
 			paramMap.item)
 
-		Logger:BasicTrace("Found " .. totalFutureStackSize .. " on " .. partyMember)
+		Logger:BasicTrace("Found %d on %s", totalFutureStackSize, partyMember)
 
 		paramMap.winners, paramMap.winningVal = ProcessorUtils:SetWinningVal_ByCompareResult(paramMap.winningVal,
 			totalFutureStackSize,
@@ -56,7 +56,7 @@ local StatFunctions = {
 
 	[targetStats.WEAPON_SCORE] = function(partyMember, paramMap)
 		if Osi.IsWeapon(paramMap.item) ~= 1 then
-			Logger:BasicTrace("Item " .. paramMap.item .. " is not a weapon according to Osi!")
+			Logger:BasicTrace("Item %s is not a weapon according to Osi!", paramMap.item)
 			return
 		end
 
@@ -71,8 +71,7 @@ local StatFunctions = {
 	[targetStats.WEAPON_ABILITY] = function(partyMember, paramMap)
 		local weaponAbility = tostring(Ext.Enums.AbilityId[Ext.Entity.Get(paramMap.item).Weapon.Ability])
 		local partyMemberAbilityScore = Osi.GetAbility(partyMember, weaponAbility)
-		Logger:BasicTrace(string.format("Weapon uses %s, %s has a score of %s", weaponAbility, partyMember,
-			partyMemberAbilityScore))
+		Logger:BasicTrace("Weapon uses %s, %s has a score of %s", weaponAbility, partyMember, partyMemberAbilityScore)
 		paramMap.winners, paramMap.winningVal = ProcessorUtils:SetWinningVal_ByCompareResult(paramMap.winningVal,
 			partyMemberAbilityScore,
 			paramMap.filter.CompareStategy,
@@ -161,13 +160,13 @@ function FilterProcessor:RegisterTargetStatProcessors(modUUID, statFunctions)
 		if not StatFunctions[targetStat] then
 			StatFunctions[targetStat] = statFunction
 
-			Logger:BasicInfo(string.format("Mod %s successfully added new targetStat function for %s",
+			Logger:BasicInfo("Mod %s successfully added new targetStat function for %s",
 				modName,
-				targetStat))
+				targetStat)
 		else
-			Logger:BasicWarning(string.format("Mod %s tried to add a new StatFunction for existing targetStat %s",
+			Logger:BasicWarning("Mod %s tried to add a new StatFunction for existing targetStat %s",
 				modName,
-				targetStat))
+				targetStat)
 		end
 	end
 end
@@ -218,8 +217,7 @@ function FilterProcessor:RegisterNewFilterProcessor(modUUID, predicateFunction, 
 	local modName = ModUtils:GetModInfoFromUUID(modUUID).Name
 
 	filterProcessors[predicateFunction] = filterProcessor
-	Logger:BasicInfo(string.format("Mod %s successfully added new filter processor!",
-		modName))
+	Logger:BasicInfo("Mod %s successfully added new filter processor!", modName)
 end
 
 --- The table that's passed to each FilterProcessor
@@ -278,13 +276,13 @@ function FilterProcessor:ExecuteFilterAgainstEligiblePartyMembers(filter,
 	end)
 
 	if not success then
-		Logger:BasicError(string.format(
+		Logger:BasicError(
 			"FilterProcessor:ExecuteFilterAgainstEligiblePartyMembers - Got error %s while attempting to process filter with paramMap %s",
-			errorResponse, Ext.Json.Stringify(FilterProcessor.ParamMap)))
+			errorResponse, Ext.Json.Stringify(FilterProcessor.ParamMap))
 	end
 	if Logger:IsLogLevelEnabled(Logger.PrintTypes.TRACE) then
-		Logger:BasicTrace(string.format("FilterProcessor finished iteration in %dms - param map is \n%s",
-			Ext.Utils.MonotonicTime() - startTime, Ext.Json.Stringify(FilterProcessor.ParamMap)))
+		Logger:BasicTrace("FilterProcessor finished iteration in %dms - param map is \n%s",
+			Ext.Utils.MonotonicTime() - startTime, Ext.Json.Stringify(FilterProcessor.ParamMap))
 	end
 
 	return #FilterProcessor.ParamMap.winners > 0 and FilterProcessor.ParamMap.winners or eligiblePartyMembers

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Processors/_PreFilterProcessors.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Processors/_PreFilterProcessors.lua
@@ -77,16 +77,16 @@ function PreFilterProcessors:RegisterPerStackPreFilterProcessor(modUUID, preFilt
 	local modName = ModUtils:GetModInfoFromUUID(modUUID).Name
 
 	if perStackPreFilterProcessors[preFilterKey] then
-		Logger:BasicWarning(string.format("Mod %s tried to add a new prefilter processor for existing prefilterKey %s",
+		Logger:BasicWarning("Mod %s tried to add a new prefilter processor for existing prefilterKey %s",
 			modName,
-			preFilterKey))
+			preFilterKey)
 
 		return false
 	else
 		perStackPreFilterProcessors[preFilterKey] = processorFunction
-		Logger:BasicInfo(string.format("Mod %s successfully added new perStack prefilterProcesor for prefilterKey %s",
+		Logger:BasicInfo("Mod %s successfully added new perStack prefilterProcesor for prefilterKey %s",
 			modName,
-			preFilterKey))
+			preFilterKey)
 		return true
 	end
 end
@@ -125,18 +125,18 @@ function PreFilterProcessors:ProcessPerStackPreFilters(prefilters,
 
 			if not prefilterResult or #prefilterResult == 0 then
 				if Logger:IsLogLevelEnabled(Logger.PrintTypes.DEBUG) then
-					Logger:BasicDebug(string.format(
+					Logger:BasicDebug(
 						"After processing per-stack PreFilter %s, no party members were considered eligible, so resetting back to list state of: %s",
 						prefilterKey,
-						Ext.Json.Stringify(survivors)))
+						Ext.Json.Stringify(survivors))
 				end
 			else
 				survivors = prefilterResult
 				if Logger:IsLogLevelEnabled(Logger.PrintTypes.DEBUG) then
-					Logger:BasicDebug(string.format(
+					Logger:BasicDebug(
 						"After processing per-stack PreFilter %s, eligible party members are %s",
 						prefilterKey,
-						Ext.Json.Stringify(survivors)))
+						Ext.Json.Stringify(survivors))
 				end
 			end
 		end
@@ -153,10 +153,10 @@ local perItemPreFilterProcessors = {
 			local totalFutureStackSize = ProcessorUtils:CalculateTotalItemCount(
 				paramMap.targetsWithAmountWon, partyMember, paramMap.inventoryHolder, paramMap.root, paramMap.item)
 
-			Logger:BasicTrace(string.format("Found %d on %s, against stack limit %d",
+			Logger:BasicTrace("Found %d on %s, against stack limit %d",
 				totalFutureStackSize,
 				partyMember,
-				stackLimit))
+				stackLimit)
 
 			if totalFutureStackSize < stackLimit then
 				table.insert(filteredSurvivors, partyMember)
@@ -178,10 +178,10 @@ local perItemPreFilterProcessors = {
 				local unencumberedLimit = tonumber(partyMemberEntity.EncumbranceStats.UnencumberedWeight)
 				local inventoryWeight = tonumber(partyMemberEntity.InventoryWeight["Weight"])
 				if (inventoryWeight + itemWeight) <= unencumberedLimit then
-					Logger:BasicTrace(string.format("Item weight %d will not encumber %s, with %d more room!",
+					Logger:BasicTrace("Item weight %d will not encumber %s, with %d more room!",
 						itemWeight,
 						partyMember,
-						unencumberedLimit - (inventoryWeight + itemWeight)))
+						unencumberedLimit - (inventoryWeight + itemWeight))
 					table.insert(filteredSurvivors, partyMember)
 				end
 			end
@@ -203,16 +203,16 @@ function PreFilterProcessors:RegisterPerItemPreFilterProcessor(modUUID, preFilte
 	local modName = ModUtils:GetModInfoFromUUID(modUUID).Name
 
 	if perItemPreFilterProcessors[preFilterKey] then
-		Logger:BasicWarning(string.format("Mod %s tried to add a new prefilter processor for existing prefilterKey %s",
+		Logger:BasicWarning("Mod %s tried to add a new prefilter processor for existing prefilterKey %s",
 			modName,
-			preFilterKey))
+			preFilterKey)
 
 		return false
 	else
 		perItemPreFilterProcessors[preFilterKey] = processorFunction
-		Logger:BasicInfo(string.format("Mod %s successfully added new perStack prefilterProcesor for prefilterKey %s",
+		Logger:BasicInfo("Mod %s successfully added new perStack prefilterProcesor for prefilterKey %s",
 			modName,
-			preFilterKey))
+			preFilterKey)
 		return true
 	end
 end
@@ -254,18 +254,18 @@ function PreFilterProcessors:ProcessPerItemPreFilters(prefilters,
 
 			if not prefilterResult or #prefilterResult == 0 then
 				if Logger:IsLogLevelEnabled(Logger.PrintTypes.DEBUG) then
-					Logger:BasicDebug(string.format(
+					Logger:BasicDebug(
 						"After processing per-item PreFilter %s, no party members were considered eligible, so resetting back to list state of: %s",
 						prefilterKey,
-						Ext.Json.Stringify(survivors)))
+						Ext.Json.Stringify(survivors))
 				end
 			else
 				survivors = prefilterResult
 				if Logger:IsLogLevelEnabled(Logger.PrintTypes.DEBUG) then
-					Logger:BasicDebug(string.format(
+					Logger:BasicDebug(
 						"After processing per-item PreFilter %s, eligible party members are %s",
 						prefilterKey,
-						Ext.Json.Stringify(survivors)))
+						Ext.Json.Stringify(survivors))
 				end
 			end
 		end

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Processors/_ProcessorUtils.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Processors/_ProcessorUtils.lua
@@ -82,7 +82,7 @@ function ProcessorUtils:CalculateTotalItemCount(targetsWithAmountWon,
 												inventoryHolder,
 												root,
 												item)
-	Logger:BasicTrace(string.format("Calculating total count of %s in inventory of %s", root, targetChar))
+	Logger:BasicTrace("Calculating total count of %s in inventory of %s", root, targetChar)
 	local totalFutureStackSize = targetsWithAmountWon[targetChar]
 
 	local itemByTemplate = Osi.GetItemByTemplateInInventory(root, targetChar)
@@ -90,26 +90,25 @@ function ProcessorUtils:CalculateTotalItemCount(targetsWithAmountWon,
 		local _, templateStackSize = Osi.GetStackAmount(itemByTemplate)
 		totalFutureStackSize = totalFutureStackSize + templateStackSize
 
-		Logger:BasicDebug(string.format("Found %d of %s already in %s's inventory", templateStackSize, root,
-			targetChar))
+		Logger:BasicDebug("Found %d of %s already in %s's inventory", templateStackSize, root, targetChar)
 	end
 
 	if TEMPLATES_BEING_TRANSFERRED[root] and TEMPLATES_BEING_TRANSFERRED[root][targetChar] then
 		totalFutureStackSize = totalFutureStackSize + TEMPLATES_BEING_TRANSFERRED[root][targetChar]
-		Logger:BasicDebug(string.format(
+		Logger:BasicDebug(
 			"Found %d of the item currently being transferreed to %s, adding to the stack size",
 			TEMPLATES_BEING_TRANSFERRED[root][targetChar],
-			targetChar))
+			targetChar)
 	end
 
 	if targetChar == inventoryHolder then
 		local amountToRemove = Osi.GetStackAmount(item)
-		Logger:BasicDebug(string.format(
+		Logger:BasicDebug(
 			"Brought down %s's, the inventoryHolder of the item, total item count of %d by %d", inventoryHolder,
-			totalFutureStackSize, amountToRemove))
+			totalFutureStackSize, amountToRemove)
 		totalFutureStackSize = totalFutureStackSize - amountToRemove
 	end
 
-	Logger:BasicDebug(string.format("Total item count for %s is %d", targetChar, totalFutureStackSize))
+	Logger:BasicDebug("Total item count for %s is %d", targetChar, totalFutureStackSize)
 	return totalFutureStackSize
 end

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Utils/_FileUtils.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Utils/_FileUtils.lua
@@ -34,10 +34,10 @@ function FileUtils:SaveTableToFile(filepath, content)
 	end)
 
 	if not jsonSuccess then
-		Ext.Utils.PrintError(string.format("Failed to convert content %s for file %s to JSON due to error \n\t%s",
+		Ext.Utils.PrintError("Failed to convert content %s for file %s to JSON due to error \n\t%s",
 			content,
 			filepath,
-			response))
+			response)
 
 		return false
 	end
@@ -55,8 +55,7 @@ function FileUtils:SaveStringContentToFile(filepath, content)
 	end)
 
 	if not success then
-		Logger:BasicError(string.format("Failed to save file %s due to error \n\t%s",
-			FileUtils:BuildAbsoluteFileTargetPath(filepath), error))
+		Logger:BasicError("Failed to save file %s due to error \n\t%s", FileUtils:BuildAbsoluteFileTargetPath(filepath), error)
 
 		return false
 	end
@@ -75,9 +74,9 @@ function FileUtils:LoadTableFile(filepath)
 	end)
 
 	if not success then
-		Logger:BasicError(string.format("Failed to parse contents of file %s due to error \n\t%s",
+		Logger:BasicError("Failed to parse contents of file %s due to error \n\t%s",
 			FileUtils:BuildAbsoluteFileTargetPath(filepath),
-			result))
+			result)
 		return false
 	else
 		return result
@@ -93,9 +92,9 @@ function FileUtils:LoadFile(filepath)
 	end)
 
 	if not success then
-		Logger:BasicError(string.format("Failed to load %s due to error\n\t%s",
+		Logger:BasicError("Failed to load %s due to error\n\t%s",
 			FileUtils:BuildAbsoluteFileTargetPath(filepath),
-			result))
+			result)
 		return nil
 	else
 		return result

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Utils/_Logger.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Utils/_Logger.lua
@@ -81,7 +81,7 @@ function Logger:BasicPrint(content, messageType, textColor, customPrefix, rainbo
         Logger:LogMessage(ConcatOutput(ConcatPrefix(customPrefix .. "  [" .. Logger.PrintTypes[messageType] .. "]", content)))
         if messageType <= Logger.PrintTypes.INFO then
             local coloredMessage = rainbowText and GetRainbowText(message) or
-            string.format("\x1b[%dm%s\x1b[0m", textColorCode, message)
+                string.format("\x1b[%dm%s\x1b[0m", textColorCode, message)
             if messageType == Logger.PrintTypes.ERROR then
                 Ext.Utils.PrintError(coloredMessage)
             elseif messageType == Logger.PrintTypes.WARNING then
@@ -93,29 +93,34 @@ function Logger:BasicPrint(content, messageType, textColor, customPrefix, rainbo
     end
 end
 
---- Convenience function for Error Logs
-function Logger:BasicError(content)
-    Logger:BasicPrint(content, Logger.PrintTypes.ERROR, TEXT_COLORS.red)
+function Logger:BasicError(content, ...)
+    if Logger:IsLogLevelEnabled(Logger.PrintTypes.ERROR) then
+        Logger:BasicPrint(string.format(content, ...), Logger.PrintTypes.ERROR, TEXT_COLORS.red)
+    end
 end
 
---- Convenience function for Warning Logs
-function Logger:BasicWarning(content)
-    Logger:BasicPrint(content, Logger.PrintTypes.WARNING, TEXT_COLORS.yellow)
+function Logger:BasicWarning(content, ...)
+    if Logger:IsLogLevelEnabled(Logger.PrintTypes.WARNING) then
+        Logger:BasicPrint(string.format(content, ...), Logger.PrintTypes.WARNING, TEXT_COLORS.yellow)
+    end
 end
 
---- Convenience function for Debug Logs
-function Logger:BasicDebug(content)
-    Logger:BasicPrint(content, Logger.PrintTypes.DEBUG)
+function Logger:BasicDebug(content, ...)
+    if Logger:IsLogLevelEnabled(Logger.PrintTypes.DEBUG) then
+        Logger:BasicPrint(string.format(content, ...), Logger.PrintTypes.DEBUG)
+    end
 end
 
---- Convenience function for Trace Logs
-function Logger:BasicTrace(content)
-    Logger:BasicPrint(content, Logger.PrintTypes.TRACE)
+function Logger:BasicTrace(content, ...)
+    if Logger:IsLogLevelEnabled(Logger.PrintTypes.TRACE) then
+        Logger:BasicPrint(string.format(content, ...), Logger.PrintTypes.TRACE)
+    end
 end
 
---- Convenience function for Info Logs
-function Logger:BasicInfo(content)
-    Logger:BasicPrint(content, Logger.PrintTypes.INFO)
+function Logger:BasicInfo(content, ...)
+    if Logger:IsLogLevelEnabled(Logger.PrintTypes.INFO) then
+        Logger:BasicPrint(string.format(content, ...), Logger.PrintTypes.INFO)
+    end
 end
 
 local logPath = 'log.txt'

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Utils/_UpgradeUtils.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/Utils/_UpgradeUtils.lua
@@ -63,16 +63,15 @@ function Upgrade:LegacyFiltersToPresets()
 
 				if success then
 					table.insert(Config.AIM.PRESETS.FILTERS_PRESETS[customPresetName], filterTableName)
-					Logger:BasicInfo(string.format("Successfully added itemFilterMap %s to preset %s", filterTableName,
-						customPresetName))
+					Logger:BasicInfo("Successfully added itemFilterMap %s to preset %s", filterTableName, customPresetName)
 				else
-					Logger:BasicWarning(string.format(
+					Logger:BasicWarning(
 						"Operation to save custom table %s failed - will not be including in custom preset %s. See previous logs for error details.",
-						filterTableName, customPresetName))
+						filterTableName, customPresetName)
 				end
 			else
-				Logger:BasicWarning(string.format("Custom FilterTable %s was empty! Will not copy over into Preset %s",
-					filterTableName, customPresetName))
+				Logger:BasicWarning("Custom FilterTable %s was empty! Will not copy over into Preset %s",
+					filterTableName, customPresetName)
 			end
 		end
 

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/_Config.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/_Config.lua
@@ -79,6 +79,6 @@ function Config.SyncConfigsAndFilters()
 
 	EntityPropertyRecorder:LoadRecordedItems()
 
-	Logger:BasicInfo(string.format("AIM has finished initialization in %dms!", Ext.Utils.MonotonicTime() - startTime))
+	Logger:BasicInfo("AIM has finished initialization in %dms!", Ext.Utils.MonotonicTime() - startTime)
 	Config.IsInitialized = true
 end

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/_EntityPropertyRecorder.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/_EntityPropertyRecorder.lua
@@ -203,7 +203,11 @@ registeredPropertyRecorders[ModUtils:GetAIMModInfo().Name] = {
 			local classes = Ext.Entity.Get(entity).Classes.Classes
 			for _, class in pairs(classes) do
 				table.insert(classRecord["Value"], tostring(Ext.StaticData.Get(class["ClassUUID"], "ClassDescription")["Name"]))
-				table.insert(subClassRecord["Value"], tostring(Ext.StaticData.Get(class["SubClassUUID"], "ClassDescription")["Name"]))
+				if Ext.StaticData.Get(class["SubClassUUID"], "ClassDescription") then
+					table.insert(subClassRecord["Value"], tostring(Ext.StaticData.Get(class["SubClassUUID"], "ClassDescription")["Name"]))
+				else
+					table.insert(subClassRecord["Value"], "N/A")
+				end
 			end
 
 			return {
@@ -231,9 +235,9 @@ function EntityPropertyRecorder:RegisterPropertyRecorders(modUUID, ...)
 		recorderCount = recorderCount + 1
 	end
 
-	Logger:BasicInfo(string.format("Mod %s registered %d new Entity Property Recorders!",
+	Logger:BasicInfo("Mod %s registered %d new Entity Property Recorders!",
 		modName,
-		recorderCount))
+		recorderCount)
 
 	return true
 end
@@ -271,25 +275,25 @@ function EntityPropertyRecorder:RecordEntityProperties(entity, respectAimDisable
 							end
 						end
 					else
-						Logger:BasicError(string.format(
+						Logger:BasicError(
 							"Error occured while attempting to process a propertyRecorder for mod %s on entity %s; error is: \n\t%s",
 							mod,
 							entity,
-							response))
+							response)
 					end
 				end
 			end
-			Logger:BasicDebug(string.format("Finished running all recorders against entity %s, writing to %s!",
+			Logger:BasicDebug("Finished running all recorders against entity %s, writing to %s!",
 				entity,
-				RECORD_FILE))
+				RECORD_FILE)
 
 			FileUtils:SaveTableToFile(RECORD_FILE, recordedEntityProperties)
 
 			return recordedTable
 		else
-			Logger:BasicWarning(string.format(
+			Logger:BasicWarning(
 				"Tried to run the EntityPropertyRecorder on entity %s, which doesn't exist (according to Osi.Exists)!",
-				entity))
+				entity)
 		end
 	end
 end

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/_ItemBlackList.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/_ItemBlackList.lua
@@ -71,9 +71,9 @@ function ItemBlackList:AddEntriesToBlackList(modUUID, blacklistedItems, blacklis
 	}
 	AddBlacklistTables(blackListEntries)
 
-	Logger:BasicInfo(string.format("Mod %s successfully added blackList entries: %s",
+	Logger:BasicInfo("Mod %s successfully added blackList entries: %s",
 		modInfo,
-		Ext.Json.Stringify(blackListEntries)))
+		Ext.Json.Stringify(blackListEntries))
 
 	-- not sure if mods would be able to add their values before we load from the file - so just a sanity check to make sure we only update the file
 	-- if it's been loaded in already. Initialization takes this into account as well
@@ -92,7 +92,7 @@ function ItemBlackList:IsItemOrTemplateInBlacklist(item, rootTemplate)
 	if item then
 		for _, itemUUID in pairs(blackListTable.Items) do
 			if item == itemUUID or string.find(item, itemUUID) then
-				Logger:BasicInfo(string.format("Item %s was found in the blacklist!", item))
+				Logger:BasicInfo("Item %s was found in the blacklist!", item)
 				return true
 			end
 		end
@@ -101,7 +101,7 @@ function ItemBlackList:IsItemOrTemplateInBlacklist(item, rootTemplate)
 	if rootTemplate then
 		for _, rootUUID in pairs(blackListTable.RootTemplates) do
 			if rootTemplate == rootUUID or string.find(rootTemplate, rootUUID) then
-				Logger:BasicInfo(string.format("RootTemplate %s was found in the blacklist!", rootTemplate))
+				Logger:BasicInfo("RootTemplate %s was found in the blacklist!", rootTemplate)
 				return true
 			end
 		end

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/_ItemFilters.lua
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/ScriptExtender/Lua/AIM/_ItemFilters.lua
@@ -6,10 +6,10 @@ ItemFilters.ItemFields = {}
 
 --- Filters that pre-filter eligible party members before a stack of items, or an item in the stack, is processed.
 ItemFilters.ItemFields.PreFilters = {
-	STACK_LIMIT = "STACK_LIMIT",                          -- Filters out any party members that have > than the specified limit
-	EXCLUDE_PARTY_MEMBERS = "EXCLUDE_PARTY_MEMBERS",      -- Array of party members to exclude from processing
+	STACK_LIMIT = "STACK_LIMIT",                                    -- Filters out any party members that have > than the specified limit
+	EXCLUDE_PARTY_MEMBERS = "EXCLUDE_PARTY_MEMBERS",                -- Array of party members to exclude from processing
 	EXCLUDE_CLASSES_AND_SUBCLASSES = "EXCLUDE_CLASSES_AND_SUBCLASSES", -- Array of (sub)classes to exclude from processing
-	ENCUMBRANCE = "ENCUMBRANCE",                          -- Internal only
+	ENCUMBRANCE = "ENCUMBRANCE",                                    -- Internal only
 }
 
 ItemFilters.FilterFields = {}
@@ -116,18 +116,18 @@ function ItemFilters:RegisterItemFilterMapPreset(modUUID, presetName, itemFilter
 			table.insert(Config.AIM.PRESETS.FILTERS_PRESETS[presetName], mapName)
 			mapCount = mapCount + 1
 		else
-			Logger:BasicError(string.format(
+			Logger:BasicError(
 				"Was unable to save itemFilterMap %s while creating preset %s for mod %s - this map will be skipped! Check previous logs for errors",
 				mapName,
 				presetName,
-				modName))
+				modName)
 		end
 	end
 
-	Logger:BasicInfo(string.format("Mod %s successfully registered %d new itemFilterMaps under preset %s",
+	Logger:BasicInfo("Mod %s successfully registered %d new itemFilterMaps under preset %s",
 		modName,
 		mapCount,
-		presetName))
+		presetName)
 
 	if Config.IsInitialized then
 		FileUtils:SaveTableToFile("config.json", Config.AIM)
@@ -157,9 +157,9 @@ local function AddItemFilterMaps(newItemFilterMaps, forceOverride, prioritizeNew
 			end
 		end
 		if Logger:IsLogLevelEnabled(Logger.PrintTypes.TRACE) then
-			Logger:BasicTrace(string.format("Finished merging itemFilterMap %s, new map is: %s",
+			Logger:BasicTrace("Finished merging itemFilterMap %s, new map is: %s",
 				newMapName,
-				Ext.Json.Stringify(itemFilterMaps[newMapName])))
+				Ext.Json.Stringify(itemFilterMaps[newMapName]))
 		end
 	end
 
@@ -176,9 +176,9 @@ function ItemFilters:LoadItemFilterPresets()
 	for presetName, presetTablesToLoad in pairs(Config.AIM.PRESETS.ACTIVE_PRESETS) do
 		Logger:BasicInfo("Loading filter preset " .. presetName)
 		if not Config.AIM.PRESETS.FILTERS_PRESETS[presetName] then
-			Logger:BasicError(string.format(
+			Logger:BasicError(
 				"Specified preset '%s' was not present in the FILTERS_PRESETS property - please specify a real preset (case sensitive). This will be skipped!",
-				presetName))
+				presetName)
 			goto continue
 		end
 		loadedPresets = loadedPresets + 1
@@ -199,10 +199,10 @@ function ItemFilters:LoadItemFilterPresets()
 
 				if filterTable then
 					local success, result = pcall(function()
-						Logger:BasicInfo(string.format(
+						Logger:BasicInfo(
 							"Merging %s/%s.json into active itemFilterMaps",
 							presetName,
-							filterTableName))
+							filterTableName)
 
 						AddItemFilterMaps({ [filterTableName] = Ext.Json.Parse(filterTable) },
 							false,
@@ -211,21 +211,21 @@ function ItemFilters:LoadItemFilterPresets()
 					end)
 
 					if not success then
-						Logger:BasicError(string.format("Could not merge table %s from preset %s due to error [%s]",
+						Logger:BasicError("Could not merge table %s from preset %s due to error [%s]",
 							filterTableName,
 							presetName,
-							result))
+							result)
 					else
 						loadedTables = loadedTables + 1
 					end
 				else
-					Logger:BasicError("Could not find filter table file " .. filterTableFilePath)
+					Logger:BasicError("Could not find filter table file %s", filterTableFilePath)
 				end
 			else
-				Logger:BasicInfo(string.format(
+				Logger:BasicInfo(
 					"The table %s in Preset %s was excluded from the ACTIVE_PRESETS list, so skipping it!",
 					filterTableName,
-					presetName))
+					presetName)
 			end
 		end
 		::continue::
@@ -241,14 +241,14 @@ function ItemFilters:LoadItemFilterPresets()
 	if Logger:IsLogLevelEnabled(Logger.PrintTypes.DEBUG) then
 		Logger:BasicDebug("Finished loading in presets - finalized item maps are:")
 		for itemFilterMap, itemFilterMapContent in pairs(ItemFilters.itemFilterMaps) do
-			Logger:BasicDebug(string.format("%s: %s", itemFilterMap, Ext.Json.Stringify(itemFilterMapContent)))
+			Logger:BasicDebug("%s: %s", itemFilterMap, Ext.Json.Stringify(itemFilterMapContent))
 		end
 	end
 
-	Logger:BasicInfo(string.format("Successfully merged %d Item Filter Maps from %d Preset(s) to the itemFilterMaps in %dms",
+	Logger:BasicInfo("Successfully merged %d Item Filter Maps from %d Preset(s) to the itemFilterMaps in %dms",
 		loadedTables,
 		loadedPresets,
-		Ext.Utils.MonotonicTime() - startTime))
+		Ext.Utils.MonotonicTime() - startTime)
 
 	return true
 end
@@ -385,9 +385,9 @@ function ItemFilters:RegisterItemFilterLookupFunction(modUUID, ...)
 		funcCount = funcCount + 1
 	end
 
-	Logger:BasicInfo(string.format("Mod %s successfully added %d new ItemFilterLookupFunction(s)!",
+	Logger:BasicInfo("Mod %s successfully added %d new ItemFilterLookupFunction(s)!",
 		modName,
-		funcCount))
+		funcCount)
 
 	return true
 end
@@ -408,12 +408,12 @@ function ItemFilters:SearchForItemFilters(item, root, inventoryHolder)
 		end
 		)
 		if not success then
-			Logger:BasicError(string.format(
+			Logger:BasicError(
 				"ItemFilters:SearchForItemFilters - Received error executing itemFilterLoop for item %s, root %s, inventoryHolder %s: [%s]",
 				item,
 				root,
 				inventoryHolder,
-				errorMessage))
+				errorMessage)
 		end
 	end
 

--- a/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/meta.lsx
+++ b/Automatic_Inventory_Manager/Mods/Automatic_Inventory_Manager/meta.lsx
@@ -22,10 +22,10 @@
           <attribute id="Tags" type="LSWString" value="add41a41-a1a8-4405-ae7f-ce12a0788a1a" />
           <attribute id="Type" type="FixedString" value="Add-on" />
           <attribute id="UUID" type="FixedString" value="23bdda0c-a671-498f-89f5-a69e8d3a4b52" />
-          <attribute id="Version64" type="int64" value="72339069014638592" />
+          <attribute id="Version64" type="int64" value="72339071162122240" />
           <children>
             <node id="PublishVersion">
-              <attribute id="Version64" type="int64" value="72339069014638592" />
+              <attribute id="Version64" type="int64" value="72339071162122240" />
             </node>
             <node id="Scripts" />
             <node id="TargetModes">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Mod Users** - to review any changes more in-depth, check the relevant sections of [the wiki](https://github.com/osirisOfGit/BG3_Automatic_Inventory_Manager/wiki)
 
+## [2.2.1]
+### Mod Users
+#### Changed
+- Processing on item pickup no longer happens when there's only one character in the party, but items are still tagged
+- ALL_DEFAULTS preset
+	- Changed priority of Proficiency filter for all Equipment up to 51 from 99
+- Improved some log info
+
+### Internal Only
+#### Changed
+- Stopped being the dumb kind of lazy and consolidated string.format into the Logger:Basic* funcs
+#### Fixed
+- Non-nil safe logs
+
 ## [2.2.0]
 ### Mod Users
 #### Added


### PR DESCRIPTION
### Mod Users
#### Changed
- Processing on item pickup no longer happens when there's only one character in the party, but items are still tagged
- ALL_DEFAULTS preset
	- Changed priority of Proficiency filter for all Equipment up to 51 from 99
- Improved some log info

### Internal Only
#### Changed
- Stopped being the dumb kind of lazy and consolidated string.format into the Logger:Basic* funcs
#### Fixed
- Non-nil safe logs